### PR TITLE
Simplify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Made with [Rust](https://www.rust-lang.org), [Actix](https://actix.rs/), [Infern
 
 ### Docker
 
+Make sure you have both docker and docker-compose(>=`1.24.0`) installed.
+
 ```
-apt install docker docker-compose
 mkdir /lemmy/
 cd /lemmy/
 wget https://github.com/dessalines/lemmy/blob/master/docker/docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Made with [Rust](https://www.rust-lang.org), [Actix](https://actix.rs/), [Infern
 
 ### Docker
 
-Make sure you have both docker and docker-compose(>=`1.24.0`) installed.
-
 ```
-git clone https://github.com/dessalines/lemmy
-cd lemmy/docker
+apt install docker docker-compose
+mkdir /lemmy/
+cd /lemmy/
+wget https://github.com/dessalines/lemmy/blob/master/docker/docker-compose.yml
 docker-compose up -d
 ```
 


### PR DESCRIPTION
I havent tested this, but from looking at the docker-compose file, there seems to be no need to clone the git repo onto the server.