### PR TITLE
Only bind to local ports in docker-compose.yml

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../../
       dockerfile: docker/dev/Dockerfile
     ports:
-      - "8536:8536"
+      - "127.0.0.1:8536:8536"
     environment:
       - LEMMY_FRONT_END_DIR=/app/dist
       - DATABASE_URL=${DATABASE_URL}
@@ -32,7 +32,7 @@ services:
   lemmy_pictshare:
     image: hascheksolutions/pictshare:latest
     ports:
-      - "8537:80"
+      - "127.0.0.1:8537:80"
     volumes:
       - lemmy_pictshare:/usr/share/nginx/html/data
 volumes:

--- a/docker/nocross/docker-compose.yml
+++ b/docker/nocross/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../../
       dockerfile: docker/nocross/Dockerfile
     ports:
-      - "8536:8536"
+      - "127.0.0.1:8536:8536"
     environment:
       - LEMMY_FRONT_END_DIR=/app/dist
       - DATABASE_URL=${DATABASE_URL}

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   lemmy:
     image: dessalines/lemmy:v0.3.0
     ports:
-      - "8536:8536"
+      - "127.0.0.1:8536:8536"
     environment:
       - LEMMY_FRONT_END_DIR=/app/dist
       - DATABASE_URL=${DATABASE_URL}
@@ -30,7 +30,7 @@ services:
   lemmy_pictshare:
     image: hascheksolutions/pictshare:latest
     ports:
-      - "8537:80"
+      - "127.0.0.1:8537:80"
     volumes:
       - lemmy_pictshare:/usr/share/nginx/html/data
 volumes:


### PR DESCRIPTION
With the current configuration, lemmy and pictshare are directly exposed on ports 8536/8537. That means users can go around nginx, and possibly cause problems. With this change, these services will only be reachable from localhost.