### PR TITLE
chore: simplify validUrl fn

### DIFF
--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -75,11 +75,11 @@ export function mdToHtml(text: string) {
   return {__html: md.render(text)};
 }
 
-export function getUnixTime(text: string): number {
+export function getUnixTime(text: string): number { 
   return text ? new Date(text).getTime()/1000 : undefined;
 }
 
-export function addTypeInfo<T>(arr: Array<T>, name: string): Array<{type_: string, data: T}> {
+export function addTypeInfo<T>(arr: Array<T>, name: string): Array<{type_: string, data: T}> {  
   return arr.map(e => {return {type_: name, data: e}});
 }
 
@@ -89,9 +89,9 @@ export function canMod(user: User, modIds: Array<number>, creator_id: number, on
     let yourIndex = modIds.findIndex(id => id == user.id);
     if (yourIndex == -1) {
       return false;
-    } else {
+    } else { 
       // onSelf +1 on mod actions not for yourself, IE ban, remove, etc
-      modIds = modIds.slice(0, yourIndex+(onSelf ? 0 : 1));
+      modIds = modIds.slice(0, yourIndex+(onSelf ? 0 : 1)); 
       return !modIds.includes(creator_id);
     }
   } else {
@@ -174,9 +174,9 @@ export function debounce(func: any, wait: number = 500, immediate: boolean = fal
   //   and not already in a timeout then the answer is: Yes
   var callNow = immediate && !timeout;
 
-  // This is the basic debounce behaviour where you can call this
-  //   function several times, but it will only execute once
-  //   [before or after imposing a delay].
+  // This is the basic debounce behaviour where you can call this 
+  //   function several times, but it will only execute once 
+  //   [before or after imposing a delay]. 
   //   Each time the returned function is called, the timer starts over.
   clearTimeout(timeout);
 
@@ -190,7 +190,7 @@ export function debounce(func: any, wait: number = 500, immediate: boolean = fal
     // Check if the function already ran with the immediate flag
     if (!immediate) {
       // Call the original function with apply
-      // apply lets you define the 'this' object as well as the arguments
+      // apply lets you define the 'this' object as well as the arguments 
       //    (both captured before setTimeout)
       func.apply(context, args);
     }
@@ -247,6 +247,6 @@ export function setTheme(theme: string = 'darkly') {
       styleSheet.removeAttribute("disabled");
     } else {
       styleSheet.setAttribute("disabled", "disabled");
-    }
+    }      
   }
 }

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -75,11 +75,11 @@ export function mdToHtml(text: string) {
   return {__html: md.render(text)};
 }
 
-export function getUnixTime(text: string): number { 
+export function getUnixTime(text: string): number {
   return text ? new Date(text).getTime()/1000 : undefined;
 }
 
-export function addTypeInfo<T>(arr: Array<T>, name: string): Array<{type_: string, data: T}> {  
+export function addTypeInfo<T>(arr: Array<T>, name: string): Array<{type_: string, data: T}> {
   return arr.map(e => {return {type_: name, data: e}});
 }
 
@@ -89,9 +89,9 @@ export function canMod(user: User, modIds: Array<number>, creator_id: number, on
     let yourIndex = modIds.findIndex(id => id == user.id);
     if (yourIndex == -1) {
       return false;
-    } else { 
+    } else {
       // onSelf +1 on mod actions not for yourself, IE ban, remove, etc
-      modIds = modIds.slice(0, yourIndex+(onSelf ? 0 : 1)); 
+      modIds = modIds.slice(0, yourIndex+(onSelf ? 0 : 1));
       return !modIds.includes(creator_id);
     }
   } else {
@@ -116,13 +116,11 @@ export function isVideo(url: string) {
 }
 
 export function validURL(str: string) {
-  var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
-    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
-    '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
-    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
-    '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
-    '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
-  return !!pattern.test(str);
+  try {
+    return !!new URL(str);
+  } catch {
+    return false;
+  }
 }
 
 export function capitalizeFirstLetter(str: string): string {
@@ -176,9 +174,9 @@ export function debounce(func: any, wait: number = 500, immediate: boolean = fal
   //   and not already in a timeout then the answer is: Yes
   var callNow = immediate && !timeout;
 
-  // This is the basic debounce behaviour where you can call this 
-  //   function several times, but it will only execute once 
-  //   [before or after imposing a delay]. 
+  // This is the basic debounce behaviour where you can call this
+  //   function several times, but it will only execute once
+  //   [before or after imposing a delay].
   //   Each time the returned function is called, the timer starts over.
   clearTimeout(timeout);
 
@@ -192,7 +190,7 @@ export function debounce(func: any, wait: number = 500, immediate: boolean = fal
     // Check if the function already ran with the immediate flag
     if (!immediate) {
       // Call the original function with apply
-      // apply lets you define the 'this' object as well as the arguments 
+      // apply lets you define the 'this' object as well as the arguments
       //    (both captured before setTimeout)
       func.apply(context, args);
     }
@@ -249,6 +247,6 @@ export function setTheme(theme: string = 'darkly') {
       styleSheet.removeAttribute("disabled");
     } else {
       styleSheet.setAttribute("disabled", "disabled");
-    }      
+    }
   }
 }


### PR DESCRIPTION
I was reading through the UI code to get familiar with where things are and came across that regex. Using the URL constructor to validate a URL is probably more maintainable for anyone who isn't a regex whiz (I'm not a regex whiz), so might be friendlier to future contributors.

There are some whitespace-only changes in the file; my Vim setup trims trailing whitespace by default except in Markdown.