### PR TITLE
add cross-building for arm

### DIFF
--- a/docker/dev/Dockerfile.aarch64
+++ b/docker/dev/Dockerfile.aarch64
@@ -1,0 +1,78 @@
+FROM node:10-jessie as node
+
+WORKDIR /app/ui
+
+# Cache deps
+COPY ui/package.json ui/yarn.lock ./
+RUN yarn install --pure-lockfile
+
+# Build
+COPY ui /app/ui
+RUN yarn build
+
+
+# contains qemu-*-static for cross-compilation
+FROM multiarch/qemu-user-static as qemu
+
+
+FROM arm64v8/rust:1.37-buster as rust
+
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+#COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
+
+
+# Install musl
+#RUN apt-get update && apt-get install -y mc
+#RUN apt-get install -y musl-tools mc
+#libpq-dev mc
+#RUN rustup target add ${TARGET}
+
+# Cache deps
+WORKDIR /app
+RUN USER=root cargo new server
+WORKDIR /app/server
+COPY server/Cargo.toml server/Cargo.lock ./
+RUN  mkdir -p ./src/bin \
+  && echo 'fn main() { println!("Dummy") }' > ./src/bin/main.rs
+#RUN cargo build --release
+RUN cargo build
+COPY server/src ./src/
+COPY server/migrations ./migrations/
+RUN rm -f ./target/release/deps/lemmy_server* ; rm -f ./target/debug/deps/lemmy_server*
+
+
+# build for release
+#RUN cargo build --frozen --release
+RUN cargo build --frozen
+
+# Get diesel-cli on there just in case
+# RUN cargo install diesel_cli --no-default-features --features postgres
+
+RUN cp /app/server/target/debug/lemmy_server /app/server/ready
+#RUN cp /app/server/target/release/lemmy_server /app/server/ready
+
+#FROM alpine:3.10
+# debian because build with dynamic linking with debian:buster
+FROM arm64v8/debian:buster-slim as lemmy
+
+#COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+
+# Install libpq for postgres
+#RUN apk add libpq
+RUN apt-get update && apt-get install -y libpq5
+
+RUN addgroup --gid 1000 lemmy
+# for alpine
+#RUN adduser -D -s /bin/sh -u 1000 -G lemmy lemmy
+# for debian
+RUN adduser --disabled-password --shell /bin/sh --uid 1000 --ingroup lemmy lemmy
+
+# Copy resources
+COPY --from=rust /app/server/ready /app/lemmy
+COPY --from=node /app/ui/dist /app/dist
+
+RUN chown lemmy:lemmy /app/lemmy
+USER lemmy
+EXPOSE 8536
+CMD ["/app/lemmy"]

--- a/docker/dev/Dockerfile.armv7hf
+++ b/docker/dev/Dockerfile.armv7hf
@@ -1,0 +1,77 @@
+FROM node:10-jessie as node
+
+WORKDIR /app/ui
+
+# Cache deps
+COPY ui/package.json ui/yarn.lock ./
+RUN yarn install --pure-lockfile
+
+# Build
+COPY ui /app/ui
+RUN yarn build
+
+
+# contains qemu-*-static for cross-compilation
+FROM multiarch/qemu-user-static as qemu
+
+
+FROM arm32v7/rust:1.37-buster as rust
+
+#COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
+
+
+# Install musl
+#RUN apt-get update && apt-get install -y mc
+#RUN apt-get install -y musl-tools mc
+#libpq-dev mc
+#RUN rustup target add ${TARGET}
+
+# Cache deps
+WORKDIR /app
+RUN USER=root cargo new server
+WORKDIR /app/server
+COPY server/Cargo.toml server/Cargo.lock ./
+RUN  mkdir -p ./src/bin \
+  && echo 'fn main() { println!("Dummy") }' > ./src/bin/main.rs
+#RUN cargo build --release
+RUN cargo build
+COPY server/src ./src/
+COPY server/migrations ./migrations/
+RUN rm -f ./target/release/deps/lemmy_server* ; rm -f ./target/debug/deps/lemmy_server*
+
+
+# build for release
+#RUN cargo build --frozen --release
+RUN cargo build --frozen
+
+# Get diesel-cli on there just in case
+# RUN cargo install diesel_cli --no-default-features --features postgres
+
+RUN cp /app/server/target/debug/lemmy_server /app/server/ready
+#RUN cp /app/server/target/release/lemmy_server /app/server/ready
+
+#FROM alpine:3.10
+# debian because build with dynamic linking with debian:buster
+FROM arm32v7/debian:buster-slim as lemmy
+
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
+
+# Install libpq for postgres
+#RUN apk add libpq
+RUN apt-get update && apt-get install -y libpq5
+
+RUN addgroup --gid 1000 lemmy
+# for alpine
+#RUN adduser -D -s /bin/sh -u 1000 -G lemmy lemmy
+# for debian
+RUN adduser --disabled-password --shell /bin/sh --uid 1000 --ingroup lemmy lemmy
+
+# Copy resources
+COPY --from=rust /app/server/ready /app/lemmy
+COPY --from=node /app/ui/dist /app/dist
+
+RUN chown lemmy:lemmy /app/lemmy
+USER lemmy
+EXPOSE 8536
+CMD ["/app/lemmy"]

--- a/docker/dev/d
+++ b/docker/dev/d
@@ -1,0 +1,62 @@
+#!/bin/bash -x
+
+#git checkout master
+
+# Creating the new tag
+new_tag="$1"
+#git tag $new_tag
+
+# Setting the version on the front end
+pushd ../../ui/
+node set_version.js
+#git add src/version.ts
+popd
+
+# Changing the docker-compose prod
+sed -i "s/dessalines\/lemmy:.*/dessalines\/lemmy:$new_tag/" ../prod/docker-compose.yml
+#git add ../prod/docker-compose.yml
+
+# The commit
+#git commit -m"Upping version."
+
+#git push origin $new_tag
+#git push
+
+# Rebuilding docker
+docker-compose build
+docker tag dev_lemmy:latest shtripok/lemmy:x64-$new_tag
+docker push shtripok/lemmy:x64-$new_tag
+
+# Build for Raspberry Pi armv7hf
+docker build -t lemmy:armv7hf -f Dockerfile.armv7hf ../../
+docker tag lemmy:armv7hf shtripok/lemmy:armv7hf-$new_tag
+docker push shtripok/lemmy:armv7hf-$new_tag
+
+
+docker build -t lemmy:aarch64 -f Dockerfile.aarch64 ../../
+docker tag lemmy:aarch64 shtripok/lemmy:arm64-$new_tag
+docker push shtripok/lemmy:arm-$new_tag
+
+docker manifest create shtripok/lemmy:latest \
+    shtripok/lemmy:armv7hf-$new_tag \
+    shtripok/lemmy:x64-$new_tag \
+    shtripok/lemmy:arm64-$new_tag
+
+
+#docker manifest create shtripok/pictshare:latest \
+#shtripok/pictshare:armv7 \
+#shtripok/pictshare:x64 \
+#shtripok/pictshare:arm64
+
+docker manifest push shtripok/pictshare:latest
+
+# Rebuilding the docker nocross
+# pushd ../nocross
+# docker-compose build
+# docker tag nocross_lemmy:latest dessalines/lemmy:nocross-$new_tag
+# docker push dessalines/lemmy:$new_tag
+# popd
+
+# Pushing to any ansible deploys
+#cd ../../ansible
+#ansible-playbook lemmy.yml --become


### PR DESCRIPTION
Look, please. Hope you can to try to run it after tiny modification.
I not good with git and github, then I not enough brave to try to run script with intrusive git commands.
Then I copy your batch, comment out git-related, and add building for 2 arm platform.

To have possible to test with dockerhub, there names are shtripok/* instead dessalines.

Would you please to look, change your prefix, and try to build as you do it usualy?
I will check images on arm hardware if you successfuly build it and push to dockerhub.

I not test last step with aarch64 — it's too late, no time to run full, but there all should be same as armv7, only architecture-related names differs.

And I have to change your #!/bin/sh to #!/bin/bash in batch file, because in my ubuntu sh is not a bash, and script work wrong. as bash it work correct.

If build will run good on your hardware — you can try to change debug build to release, and compare build time. Possible you found `--release` acceptable for use. It's only question of a build time.