### PR TITLE
Add --release flag to cargo run

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ cd ui
 yarn
 yarn build
 cd ../server
-cargo run
+cargo run --release
 
 # For live coding, where both the front and back end, automagically reload on any save, do:
 # cd ui && yarn start


### PR DESCRIPTION
`cargo run` builds & runs projects in the `dev` profile by default. The `dev` profile is intended for debugging, so `rustc` performs little to no optimizations in it (its default `opt-level` is `0`).
Passing the `--release` flag to `cargo run` builds & runs projects using the `release` profile, which has an `opt-level` of `3`, thus enabling `rustc` to optimize aggressively. The result is faster runtime performance and smaller binary sizes in exchange for slower compilation times.

See [this link](https://doc.rust-lang.org/book/ch14-01-release-profiles.html) for more info.