### PR TITLE
Some debug build changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ansible/inventory
 ansible/passwords/
+.idea

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -21,13 +21,13 @@ COPY server/Cargo.toml server/Cargo.lock ./
 RUN sudo chown -R rust:rust .
 RUN mkdir -p ./src/bin \
   && echo 'fn main() { println!("Dummy") }' > ./src/bin/main.rs 
-RUN cargo build --release
-RUN rm -f ./target/x86_64-unknown-linux-musl/release/deps/lemmy_server*
+RUN cargo build
+#RUN rm -f ./target/x86_64-unknown-linux-musl/debug/deps/lemmy_server*
 COPY server/src ./src/
 COPY server/migrations ./migrations/
 
-# Build for release
-RUN cargo build --frozen --release
+# Build for debug
+RUN cargo build --frozen
 
 # Get diesel-cli on there just in case
 # RUN cargo install diesel_cli --no-default-features --features postgres
@@ -38,7 +38,7 @@ FROM alpine:3.10
 RUN apk add libpq
 
 # Copy resources
-COPY --from=rust /app/server/target/x86_64-unknown-linux-musl/release/lemmy_server /app/lemmy
+COPY --from=rust /app/server/target/x86_64-unknown-linux-musl/debug/lemmy_server /app/lemmy
 COPY --from=node /app/ui/dist /app/dist
 RUN addgroup -g 1000 lemmy
 RUN adduser -D -s /bin/sh -u 1000 -G lemmy lemmy

--- a/docker/dev/docker_update.sh
+++ b/docker/dev/docker_update.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose up -d --no-deps --build
+sudo docker-compose up --no-deps --build


### PR DESCRIPTION
Not sure why the dev dockerfile builds a release, makes more sense like this. The rm call doesnt really do anything that I can tell (it definitely wont save space like this).

For the update file, I added sudo [because of this](https://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/). But I can remove that and run `sudo ./docker_update.sh` if you prefer that way. I also removed the -d flag so logs are easier to see. The more I think about this, the more I feel we should just get rid of this file and put the command into the readme...

Last change is adding the intellij folder to .gitignore. Btw, I'm curious what setup/IDE you use for development. Intellij + Docker seems cool, but not perfect.