### PR TITLE
Use correct database environment variable in docs

### DIFF
--- a/docs/src/contributing_local_development.md
+++ b/docs/src/contributing_local_development.md
@@ -9,7 +9,7 @@
 ```bash
  psql -c "create user lemmy with password 'password' superuser;" -U postgres
  psql -c 'create database lemmy with owner lemmy;' -U postgres
- export DATABASE_URL=postgres://lemmy:password@localhost:5432/lemmy
+ export LEMMY_DATABASE_URL=postgres://lemmy:password@localhost:5432/lemmy
 ```
 
 #### Running


### PR DESCRIPTION
The database URL is read from `LEMMY_DATABASE_URL`:

https://github.com/dessalines/lemmy/blob/318049174833ab221a60b13708f1ce7e36ceeb54/server/src/settings.rs#L90