### PR TITLE
Add comment sorting by Old (date, ascending) to frontend

### DIFF
--- a/ui/src/components/post.tsx
+++ b/ui/src/components/post.tsx
@@ -235,6 +235,18 @@ export class Post extends Component<any, PostState> {
             onChange={linkEvent(this, this.handleCommentSortChange)}
           />
         </label>
+        <label
+          className={`btn btn-sm btn-secondary pointer ${this.state
+            .commentSort === CommentSortType.Old && 'active'}`}
+        >
+          {i18n.t('old')}
+          <input
+            type="radio"
+            value={CommentSortType.Old}
+            checked={this.state.commentSort === CommentSortType.Old}
+            onChange={linkEvent(this, this.handleCommentSortChange)}
+          />
+        </label>
       </div>
     );
   }
@@ -316,6 +328,13 @@ export class Post extends Component<any, PostState> {
           +a.comment.removed - +b.comment.removed ||
           +a.comment.deleted - +b.comment.deleted ||
           b.comment.published.localeCompare(a.comment.published)
+      );
+    } else if (this.state.commentSort == CommentSortType.Old) {
+      tree.sort(
+        (a, b) =>
+          +a.comment.removed - +b.comment.removed ||
+          +a.comment.deleted - +b.comment.deleted ||
+          a.comment.published.localeCompare(b.comment.published)
       );
     } else if (this.state.commentSort == CommentSortType.Hot) {
       tree.sort(

--- a/ui/src/interfaces.ts
+++ b/ui/src/interfaces.ts
@@ -47,6 +47,7 @@ export enum CommentSortType {
   Hot,
   Top,
   New,
+  Old,
 }
 
 export enum ListingType {

--- a/ui/src/translations/en.ts
+++ b/ui/src/translations/en.ts
@@ -97,6 +97,7 @@ export const en = {
     sort_type: 'Sort type',
     hot: 'Hot',
     new: 'New',
+    old: 'Old',
     top_day: 'Top day',
     week: 'Week',
     month: 'Month',


### PR DESCRIPTION
This adds an option in the frontend to sort by Old (that is ascending sort by date, oldest comment first). This is a fairly natural sort for comments on a post in particular. 

Post comments are not sorted on the backend (`GetPost` returns sorted by date descending), so there's nothing to do there. 

The frontend code does essentially the reverse of the New sort.

Screenshot:
![sorted comments](https://user-images.githubusercontent.com/156239/73296256-a2b2ff00-4209-11ea-9790-b89e2bef243f.png)
