### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ init_db_final=0
 while [ "$init_db_valid" == 0 ]
 do
   read -p "Initialize database (y/n)? " init_db
-  case "${init_db,,}" in 
+  case "${init_db}" in 
     y|yes ) init_db_valid=1; init_db_final=1;;
     n|no ) init_db_valid=1; init_db_final=0;;
     * ) echo "Invalid input" 1>&2;;


### PR DESCRIPTION
extraneous commas were causing an error on line #19

```
Initialize database (y/n)? n
./install.sh: line 19: ${init_db,,}: bad substitution
```